### PR TITLE
feat: add UI index exports

### DIFF
--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -1,15 +1,15 @@
-import { Button } from "@/components/ui/button";
 import {
+  Button,
   Card,
   CardContent,
   CardDescription,
   CardFooter,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Separator } from "@/components/ui/separator";
+  Input,
+  Label,
+  Separator,
+} from "@/components/ui";
 import type { SVGProps } from "react";
 
 export default function SignInPage() {

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,0 +1,12 @@
+export { Button } from "./button";
+export {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "./card";
+export { Input } from "./input";
+export { Label } from "./label";
+export { Separator } from "./separator";


### PR DESCRIPTION
## Summary
- add a barrel file in `components/ui` that re-exports the existing UI components with named exports
- update the sign-in page to consume the new barrel exports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8b0187c18832ab3259212a50f7afe