### PR TITLE
feat: centralize ui tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,11 +5,79 @@
   --background: #f8fafc;
   --foreground: #0f172a;
 
+  --surface: #ffffff;
+  --surface-foreground: oklch(12.9% 0.042 264.695);
+  --muted: oklch(44.6% 0.043 257.281);
+  --muted-foreground: oklch(55.4% 0.046 257.417);
+  --border: oklch(92.9% 0.013 255.508);
+  --border-strong: oklch(86.9% 0.022 252.894);
+  --label-foreground: oklch(37.2% 0.044 257.287);
+  --placeholder: oklch(70.4% 0.04 256.788);
+
+  --button-background: oklch(20.8% 0.042 265.755);
+  --button-background-hover: oklch(27.9% 0.041 260.031);
+  --button-foreground: #ffffff;
+  --button-outline-foreground: oklch(37.2% 0.044 257.287);
+  --button-outline-foreground-hover: oklch(20.8% 0.042 265.755);
+  --button-outline-border: oklch(92.9% 0.013 255.508);
+  --button-outline-border-hover: oklch(86.9% 0.022 252.894);
+  --button-ghost-foreground: oklch(44.6% 0.043 257.281);
+  --button-ghost-foreground-hover: oklch(20.8% 0.042 265.755);
+  --button-ghost-background-hover: oklch(96.8% 0.007 247.896);
+
+  --input-background: #ffffff;
+  --input-foreground: oklch(20.8% 0.042 265.755);
+  --input-placeholder: oklch(70.4% 0.04 256.788);
+
+  --separator: oklch(92.9% 0.013 255.508);
+
+  --focus-ring-strong: rgb(15 23 42 / 0.2);
+  --focus-ring-subtle: rgb(15 23 42 / 0.1);
+  --focus-ring-offset: #ffffff;
+
+  --shadow-card: 0 20px 50px -35px rgb(15 23 42 / 0.45);
+
+  --radius-md: 0.5rem;
+  --radius-card: 24px;
+
+  --space-none: 0px;
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --space-lg: 1.25rem;
+  --space-xl: 1.5rem;
+
+  --size-button-sm: 2.25rem;
+  --size-button-md: 2.5rem;
+  --size-button-lg: 2.75rem;
+
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-surface: var(--surface);
+  --color-surface-foreground: var(--surface-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-label: var(--label-foreground);
+  --color-placeholder: var(--placeholder);
+  --color-button: var(--button-background);
+  --color-button-hover: var(--button-background-hover);
+  --color-button-foreground: var(--button-foreground);
+  --color-separator: var(--separator);
+  --color-focus-ring-strong: var(--focus-ring-strong);
+  --color-focus-ring-subtle: var(--focus-ring-subtle);
+  --radius-md: var(--radius-md);
+  --radius-card: var(--radius-card);
+  --spacing-none: var(--space-none);
+  --spacing-xs: var(--space-xs);
+  --spacing-sm: var(--space-sm);
+  --spacing-md: var(--space-md);
+  --spacing-lg: var(--space-lg);
+  --spacing-xl: var(--space-xl);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,26 +1,89 @@
 import { forwardRef } from "react";
-import type { ButtonHTMLAttributes } from "react";
+import type { ButtonHTMLAttributes, CSSProperties } from "react";
 
+import { BORDER_RADIUS, COLORS, SPACING } from "@/config/ui";
 import { cn } from "@/lib/utils";
 
 type ButtonVariant = "default" | "outline" | "ghost";
 type ButtonSize = "default" | "sm" | "lg" | "icon";
 
-const baseStyles =
-  "inline-flex items-center justify-center rounded-lg text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-slate-900/20 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-60";
-
-const variantStyles: Record<ButtonVariant, string> = {
-  default: "bg-slate-900 text-white hover:bg-slate-800",
-  outline:
-    "border border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:text-slate-900 focus-visible:ring-slate-900/10",
-  ghost: "text-slate-600 hover:bg-slate-100 hover:text-slate-900",
+type ButtonStyleConfig = {
+  className: string;
+  vars?: CSSProperties;
 };
 
-const sizeStyles: Record<ButtonSize, string> = {
-  default: "h-10 px-4 py-2",
-  sm: "h-9 px-3",
-  lg: "h-11 px-5",
-  icon: "h-10 w-10",
+const baseStyles =
+  "inline-flex items-center justify-center rounded-[var(--button-radius)] text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--button-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--button-focus-ring-offset)] disabled:cursor-not-allowed disabled:opacity-60";
+
+const baseVars: CSSProperties = {
+  "--button-radius": BORDER_RADIUS.md,
+  "--button-focus-ring": COLORS.focusRingStrong,
+  "--button-focus-ring-offset": COLORS.focusRingOffset,
+};
+
+const variantStyles: Record<ButtonVariant, ButtonStyleConfig> = {
+  default: {
+    className:
+      "bg-[var(--button-bg)] text-[var(--button-fg)] hover:bg-[var(--button-bg-hover)]",
+    vars: {
+      "--button-bg": COLORS.buttonBackground,
+      "--button-bg-hover": COLORS.buttonBackgroundHover,
+      "--button-fg": COLORS.buttonForeground,
+    },
+  },
+  outline: {
+    className:
+      "border border-[var(--button-border)] bg-[var(--button-bg)] text-[var(--button-fg)] hover:border-[var(--button-border-hover)] hover:text-[var(--button-fg-hover)]",
+    vars: {
+      "--button-bg": COLORS.surface,
+      "--button-fg": COLORS.buttonOutlineForeground,
+      "--button-fg-hover": COLORS.buttonOutlineForegroundHover,
+      "--button-border": COLORS.buttonOutlineBorder,
+      "--button-border-hover": COLORS.buttonOutlineBorderHover,
+      "--button-focus-ring": COLORS.focusRingSubtle,
+    },
+  },
+  ghost: {
+    className:
+      "text-[var(--button-fg)] hover:bg-[var(--button-bg-hover)] hover:text-[var(--button-fg-hover)]",
+    vars: {
+      "--button-fg": COLORS.buttonGhostForeground,
+      "--button-fg-hover": COLORS.buttonGhostForegroundHover,
+      "--button-bg-hover": COLORS.buttonGhostBackgroundHover,
+    },
+  },
+};
+
+const sizeStyles: Record<ButtonSize, ButtonStyleConfig> = {
+  default: {
+    className:
+      "h-[var(--button-height-default)] px-[var(--button-padding-x-default)] py-[var(--button-padding-y-default)]",
+    vars: {
+      "--button-height-default": SPACING.buttonHeightDefault,
+      "--button-padding-x-default": SPACING.md,
+      "--button-padding-y-default": SPACING.xs,
+    },
+  },
+  sm: {
+    className: "h-[var(--button-height-sm)] px-[var(--button-padding-x-sm)]",
+    vars: {
+      "--button-height-sm": SPACING.buttonHeightSm,
+      "--button-padding-x-sm": SPACING.sm,
+    },
+  },
+  lg: {
+    className: "h-[var(--button-height-lg)] px-[var(--button-padding-x-lg)]",
+    vars: {
+      "--button-height-lg": SPACING.buttonHeightLg,
+      "--button-padding-x-lg": SPACING.lg,
+    },
+  },
+  icon: {
+    className: "h-[var(--button-height-default)] w-[var(--button-height-default)]",
+    vars: {
+      "--button-height-default": SPACING.buttonHeightDefault,
+    },
+  },
 };
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -29,12 +92,23 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = "default", size = "default", type = "button", ...props }, ref) => {
+  ({ className, variant = "default", size = "default", type = "button", style, ...props }, ref) => {
+    const variantStyle = variantStyles[variant];
+    const sizeStyle = sizeStyles[size];
+
+    const mergedStyle: CSSProperties = {
+      ...baseVars,
+      ...variantStyle.vars,
+      ...sizeStyle.vars,
+      ...style,
+    };
+
     return (
       <button
         ref={ref}
         type={type}
-        className={cn(baseStyles, variantStyles[variant], sizeStyles[size], className)}
+        style={mergedStyle}
+        className={cn(baseStyles, variantStyle.className, sizeStyle.className, className)}
         {...props}
       />
     );

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,16 +1,22 @@
 import { forwardRef } from "react";
-import type { HTMLAttributes } from "react";
+import type { CSSProperties, HTMLAttributes } from "react";
 
+import { BORDER_RADIUS, COLORS, SPACING } from "@/config/ui";
 import { cn } from "@/lib/utils";
 
 export const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
+  ({ className, style, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn(
-        "rounded-[24px] border border-slate-200 bg-white text-slate-950 shadow-[0_20px_50px_-35px_rgba(15,23,42,0.45)]",
-        className,
-      )}
+      className={cn("border", className)}
+      style={{
+        borderRadius: BORDER_RADIUS.card,
+        borderColor: COLORS.border,
+        backgroundColor: COLORS.surface,
+        color: COLORS.surfaceForeground,
+        boxShadow: COLORS.cardShadow,
+        ...style,
+      }}
       {...props}
     />
   ),
@@ -18,8 +24,22 @@ export const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
 Card.displayName = "Card";
 
 export const CardHeader = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("space-y-2 p-6 pb-0", className)} {...props} />
+  ({ className, style, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "space-y-[var(--card-header-gap)] px-[var(--card-section-padding-x)] pt-[var(--card-header-padding-top)] pb-[var(--card-header-padding-bottom)]",
+        className,
+      )}
+      style={{
+        "--card-header-gap": SPACING.xs,
+        "--card-section-padding-x": SPACING.xl,
+        "--card-header-padding-top": SPACING.xl,
+        "--card-header-padding-bottom": SPACING.none,
+        ...style,
+      } as CSSProperties}
+      {...props}
+    />
   ),
 );
 CardHeader.displayName = "CardHeader";
@@ -32,22 +52,53 @@ export const CardTitle = forwardRef<HTMLHeadingElement, HTMLAttributes<HTMLHeadi
 CardTitle.displayName = "CardTitle";
 
 export const CardDescription = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLParagraphElement>>(
-  ({ className, ...props }, ref) => (
-    <p ref={ref} className={cn("text-sm text-slate-500", className)} {...props} />
+  ({ className, style, ...props }, ref) => (
+    <p
+      ref={ref}
+      className={cn("text-sm", className)}
+      style={{ color: COLORS.mutedForeground, ...style }}
+      {...props}
+    />
   ),
 );
 CardDescription.displayName = "CardDescription";
 
 export const CardContent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("p-6 pt-4", className)} {...props} />
+  ({ className, style, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "px-[var(--card-section-padding-x)] pt-[var(--card-content-padding-top)] pb-[var(--card-content-padding-bottom)]",
+        className,
+      )}
+      style={{
+        "--card-section-padding-x": SPACING.xl,
+        "--card-content-padding-top": SPACING.md,
+        "--card-content-padding-bottom": SPACING.xl,
+        ...style,
+      } as CSSProperties}
+      {...props}
+    />
   ),
 );
 CardContent.displayName = "CardContent";
 
 export const CardFooter = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  ({ className, style, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "px-[var(--card-section-padding-x)] pt-[var(--card-footer-padding-top)] pb-[var(--card-footer-padding-bottom)]",
+        className,
+      )}
+      style={{
+        "--card-section-padding-x": SPACING.xl,
+        "--card-footer-padding-top": SPACING.none,
+        "--card-footer-padding-bottom": SPACING.xl,
+        ...style,
+      } as CSSProperties}
+      {...props}
+    />
   ),
 );
 CardFooter.displayName = "CardFooter";

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,20 +1,35 @@
 import { forwardRef } from "react";
-import type { InputHTMLAttributes } from "react";
+import type { CSSProperties, InputHTMLAttributes } from "react";
 
+import { BORDER_RADIUS, COLORS, SPACING } from "@/config/ui";
 import { cn } from "@/lib/utils";
 
 export type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type = "text", ...props }, ref) => {
+  ({ className, type = "text", style, ...props }, ref) => {
+    const inputVars: CSSProperties = {
+      "--input-radius": BORDER_RADIUS.md,
+      "--input-border": COLORS.border,
+      "--input-background": COLORS.inputBackground,
+      "--input-foreground": COLORS.inputForeground,
+      "--input-placeholder": COLORS.placeholder,
+      "--input-ring": COLORS.focusRingSubtle,
+      "--input-ring-offset": COLORS.focusRingOffset,
+      "--input-height": SPACING.buttonHeightDefault,
+      "--input-padding-x": SPACING.sm,
+      "--input-padding-y": SPACING.xs,
+    };
+
     return (
       <input
         ref={ref}
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 ring-offset-white placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-900/10 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60",
+          "flex h-[var(--input-height)] w-full rounded-[var(--input-radius)] border border-[var(--input-border)] bg-[var(--input-background)] px-[var(--input-padding-x)] py-[var(--input-padding-y)] text-sm text-[var(--input-foreground)] ring-offset-[var(--input-ring-offset)] placeholder:text-[var(--input-placeholder)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--input-ring)] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60",
           className,
         )}
+        style={{ ...inputVars, ...style }}
         {...props}
       />
     );

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,15 +1,17 @@
 import { forwardRef } from "react";
 import type { LabelHTMLAttributes } from "react";
 
+import { COLORS } from "@/config/ui";
 import { cn } from "@/lib/utils";
 
 export type LabelProps = LabelHTMLAttributes<HTMLLabelElement>;
 
 export const Label = forwardRef<HTMLLabelElement, LabelProps>(
-  ({ className, ...props }, ref) => (
+  ({ className, style, ...props }, ref) => (
     <label
       ref={ref}
-      className={cn("text-sm font-medium text-slate-700", className)}
+      className={cn("text-sm font-medium", className)}
+      style={{ color: COLORS.label, ...style }}
       {...props}
     />
   ),

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,15 +1,17 @@
 import { forwardRef } from "react";
 import type { HTMLAttributes } from "react";
 
+import { COLORS } from "@/config/ui";
 import { cn } from "@/lib/utils";
 
 export type SeparatorProps = HTMLAttributes<HTMLDivElement>;
 
 export const Separator = forwardRef<HTMLDivElement, SeparatorProps>(
-  ({ className, ...props }, ref) => (
+  ({ className, style, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn("h-px w-full bg-slate-200", className)}
+      className={cn("h-px w-full", className)}
+      style={{ backgroundColor: COLORS.separator, ...style }}
       {...props}
     />
   ),

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,15 @@
+# UI tokens
+
+The files in this directory expose the design tokens that power the shared UI primitives. The values mirror the CSS custom properties declared in [`app/globals.css`](../app/globals.css), making it possible to keep TypeScript and CSS in sync.
+
+## `COLORS`
+
+`COLORS` maps semantic color names (backgrounds, borders, button states, typography, etc.) to the matching CSS variables. Importing these tokens ensures component styles stay aligned with the palette defined in `globals.css`.
+
+## `BORDER_RADIUS`
+
+`BORDER_RADIUS` surfaces the rounded corner sizes used across the interface. Each entry points to the same CSS variable consumed by the global theme so components can set radii without hardcoding pixel values.
+
+## `SPACING`
+
+`SPACING` contains the spacing scale—padding, gaps, and control heights—that UI elements rely on. Using the exported values keeps layout measurements consistent with the CSS counterparts and allows future adjustments from a single place.

--- a/config/ui.ts
+++ b/config/ui.ts
@@ -1,0 +1,46 @@
+export const COLORS = {
+  background: "var(--background)",
+  foreground: "var(--foreground)",
+  surface: "var(--surface)",
+  surfaceForeground: "var(--surface-foreground)",
+  muted: "var(--muted)",
+  mutedForeground: "var(--muted-foreground)",
+  border: "var(--border)",
+  borderStrong: "var(--border-strong)",
+  label: "var(--label-foreground)",
+  placeholder: "var(--placeholder)",
+  separator: "var(--separator)",
+  buttonBackground: "var(--button-background)",
+  buttonBackgroundHover: "var(--button-background-hover)",
+  buttonForeground: "var(--button-foreground)",
+  buttonOutlineForeground: "var(--button-outline-foreground)",
+  buttonOutlineForegroundHover: "var(--button-outline-foreground-hover)",
+  buttonOutlineBorder: "var(--button-outline-border)",
+  buttonOutlineBorderHover: "var(--button-outline-border-hover)",
+  buttonGhostForeground: "var(--button-ghost-foreground)",
+  buttonGhostForegroundHover: "var(--button-ghost-foreground-hover)",
+  buttonGhostBackgroundHover: "var(--button-ghost-background-hover)",
+  inputBackground: "var(--input-background)",
+  inputForeground: "var(--input-foreground)",
+  focusRingStrong: "var(--focus-ring-strong)",
+  focusRingSubtle: "var(--focus-ring-subtle)",
+  focusRingOffset: "var(--focus-ring-offset)",
+  cardShadow: "var(--shadow-card)",
+} as const;
+
+export const BORDER_RADIUS = {
+  md: "var(--radius-md)",
+  card: "var(--radius-card)",
+} as const;
+
+export const SPACING = {
+  none: "var(--space-none)",
+  xs: "var(--space-xs)",
+  sm: "var(--space-sm)",
+  md: "var(--space-md)",
+  lg: "var(--space-lg)",
+  xl: "var(--space-xl)",
+  buttonHeightSm: "var(--size-button-sm)",
+  buttonHeightDefault: "var(--size-button-md)",
+  buttonHeightLg: "var(--size-button-lg)",
+} as const;


### PR DESCRIPTION
## Summary
- add shared color, radius, and spacing tokens that mirror the globals.css custom properties
- refactor button, card, input, label, and separator primitives to consume the shared tokens
- document how to work with the UI tokens for future contributors

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8b00851ec832a938c12a270a12b83