### PR TITLE
feat: refine auth screens and documentation

### DIFF
--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, type ChangeEvent, type FormEvent, type SVGProps } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
@@ -16,6 +17,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { signIn, TEST_CREDENTIALS } from "@/lib/mock-auth";
+
+const SOCIAL_OPTIONS_ID = "sign-in-social-options";
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -102,7 +105,12 @@ export default function SignInPage() {
           </CardHeader>
 
           <CardContent className="grid gap-4">
-            <div className="grid grid-cols-2 gap-4">
+            <div
+              id={SOCIAL_OPTIONS_ID}
+              className="grid grid-cols-2 gap-4"
+              role="group"
+              aria-label="Continue with a social provider"
+            >
               <Button variant="outline" className="w-full" type="button">
                 <GithubIcon className="mr-2 h-4 w-4" aria-hidden="true" />
                 GitHub
@@ -128,6 +136,7 @@ export default function SignInPage() {
                 value={email}
                 onChange={handleEmailChange}
                 placeholder="m@example.com"
+                autoComplete="email"
                 aria-invalid={errors.email ? true : undefined}
                 aria-describedby={emailErrorId}
               />
@@ -145,6 +154,7 @@ export default function SignInPage() {
                 type="password"
                 value={password}
                 onChange={handlePasswordChange}
+                autoComplete="current-password"
                 aria-invalid={errors.password ? true : undefined}
                 aria-describedby={passwordErrorId}
               />
@@ -162,9 +172,16 @@ export default function SignInPage() {
                 {errors.form}
               </p>
             ) : null}
-            <Button className="w-full" type="submit" disabled={isSubmitting}>
+            <Button className="w-full" type="submit" disabled={isSubmitting} aria-controls={SOCIAL_OPTIONS_ID}>
               {isSubmitting ? "Signing in..." : "Sign in"}
             </Button>
+            <p className="text-sm text-slate-600">
+              New to VisionForge?{" "}
+              <Link href="/sign-up" className="font-medium underline">
+                Create an account
+              </Link>
+              .
+            </p>
           </CardFooter>
         </Card>
       </form>

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import {
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+  type SVGProps,
+} from "react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { signUp } from "@/lib/mock-auth";
+
+const SSO_OPTIONS_ID = "sign-up-sso-options";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type FieldErrors = {
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+  form?: string;
+};
+
+export default function SignUpPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const ssoOptionsRef = useRef<HTMLDivElement>(null);
+
+  const handleEmailChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setEmail(event.target.value);
+    setErrors((prev) => ({ ...prev, email: undefined, form: undefined }));
+  };
+
+  const handlePasswordChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setPassword(event.target.value);
+    setErrors((prev) => ({ ...prev, password: undefined, form: undefined }));
+  };
+
+  const handleConfirmPasswordChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setConfirmPassword(event.target.value);
+    setErrors((prev) => ({ ...prev, confirmPassword: undefined, form: undefined }));
+  };
+
+  const validate = (
+    candidateEmail: string,
+    candidatePassword: string,
+    candidateConfirm: string,
+  ): FieldErrors => {
+    const validationErrors: FieldErrors = {};
+
+    if (!candidateEmail) {
+      validationErrors.email = "Email is required.";
+    } else if (!EMAIL_PATTERN.test(candidateEmail)) {
+      validationErrors.email = "Enter a valid email address.";
+    }
+
+    if (!candidatePassword) {
+      validationErrors.password = "Password is required.";
+    }
+
+    if (!candidateConfirm) {
+      validationErrors.confirmPassword = "Please confirm your password.";
+    } else if (candidateConfirm !== candidatePassword) {
+      validationErrors.confirmPassword = "Passwords do not match.";
+    }
+
+    return validationErrors;
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedEmail = email.trim();
+    const trimmedPassword = password.trim();
+    const trimmedConfirm = confirmPassword.trim();
+    const validationErrors = validate(trimmedEmail, trimmedPassword, trimmedConfirm);
+
+    if (
+      validationErrors.email ||
+      validationErrors.password ||
+      validationErrors.confirmPassword
+    ) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setErrors({});
+    setIsSubmitting(true);
+
+    try {
+      await signUp(trimmedEmail, trimmedPassword);
+      setEmail("");
+      setPassword("");
+      setConfirmPassword("");
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unable to create account. Please try again.";
+      setErrors({ form: message });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const emailErrorId = errors.email ? "email-error" : undefined;
+  const passwordErrorId = errors.password ? "password-error" : undefined;
+  const confirmErrorId = errors.confirmPassword ? "confirm-password-error" : undefined;
+
+  const handleSsoButtonClick = () => {
+    if (!ssoOptionsRef.current) {
+      return;
+    }
+
+    ssoOptionsRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+    ssoOptionsRef.current.focus({ preventScroll: true });
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-100 p-4">
+      <form onSubmit={handleSubmit} className="w-[350px]" noValidate>
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle>Create an account</CardTitle>
+            <CardDescription>
+              Enter your email and password to get started. Already have an account?{" "}
+              <Link href="/sign-in" className="underline">
+                Sign in.
+              </Link>
+            </CardDescription>
+          </CardHeader>
+
+          <CardContent className="grid gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={handleEmailChange}
+                placeholder="name@example.com"
+                aria-invalid={errors.email ? true : undefined}
+                aria-describedby={emailErrorId}
+              />
+              {errors.email ? (
+                <p id={emailErrorId} className="text-sm text-red-500" role="alert">
+                  {errors.email}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={handlePasswordChange}
+                aria-invalid={errors.password ? true : undefined}
+                aria-describedby={passwordErrorId}
+              />
+              {errors.password ? (
+                <p id={passwordErrorId} className="text-sm text-red-500" role="alert">
+                  {errors.password}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="confirmPassword">Confirm Password</Label>
+              <Input
+                id="confirmPassword"
+                type="password"
+                value={confirmPassword}
+                onChange={handleConfirmPasswordChange}
+                aria-invalid={errors.confirmPassword ? true : undefined}
+                aria-describedby={confirmErrorId}
+              />
+              {errors.confirmPassword ? (
+                <p id={confirmErrorId} className="text-sm text-red-500" role="alert">
+                  {errors.confirmPassword}
+                </p>
+              ) : null}
+            </div>
+          </CardContent>
+
+          <CardFooter className="flex flex-col gap-3">
+            {errors.form ? (
+              <p className="text-sm text-red-500" role="alert">
+                {errors.form}
+              </p>
+            ) : null}
+            <Button className="w-full" type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Creating..." : "Create Account"}
+            </Button>
+            <Button
+              className="w-full"
+              type="button"
+              variant="outline"
+              onClick={handleSsoButtonClick}
+              aria-controls={SSO_OPTIONS_ID}
+            >
+              SSO
+            </Button>
+          </CardFooter>
+        </Card>
+
+        <div className="mt-6">
+          <div className="relative">
+            <Separator />
+            <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-slate-100 px-3 text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+              OR CONTINUE WITH
+            </span>
+          </div>
+          <div
+            id={SSO_OPTIONS_ID}
+            ref={ssoOptionsRef}
+            className="mt-6 grid grid-cols-4 gap-4"
+            role="group"
+            aria-label="Sign up with a social provider"
+            tabIndex={-1}
+          >
+            <Button variant="outline" size="icon" type="button">
+              <GoogleIcon className="h-4 w-4" aria-hidden="true" />
+              <span className="sr-only">Sign up with Google</span>
+            </Button>
+            <Button variant="outline" size="icon" type="button">
+              <XIcon className="h-4 w-4" aria-hidden="true" />
+              <span className="sr-only">Sign up with X</span>
+            </Button>
+            <Button variant="outline" size="icon" type="button">
+              <GithubIcon className="h-4 w-4" aria-hidden="true" />
+              <span className="sr-only">Sign up with GitHub</span>
+            </Button>
+            <Button variant="outline" size="icon" type="button">
+              <FacebookIcon className="h-4 w-4" aria-hidden="true" />
+              <span className="sr-only">Sign up with Facebook</span>
+            </Button>
+          </div>
+        </div>
+
+        <p className="mt-6 text-center text-xs text-slate-500">
+          By creating an account, you agree to our{" "}
+          <Link href="/terms" className="underline">
+            Terms of Service
+          </Link>{" "}
+          and{" "}
+          <Link href="/privacy" className="underline">
+            Privacy Policy
+          </Link>
+          .
+        </p>
+      </form>
+    </div>
+  );
+}
+
+function GoogleIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" role="img" aria-hidden="true" {...props}>
+      <path d="M21.6 12.23c0-.74-.07-1.45-.2-2.13H12v4.03h5.4a4.62 4.62 0 0 1-2 3.04v2.54h3.24c1.9-1.75 2.96-4.32 2.96-7.48Z" fill="#4285F4" />
+      <path d="M12 22c2.7 0 4.97-.9 6.63-2.46l-3.24-2.54c-.9.6-2.06.95-3.39.95-2.61 0-4.81-1.76-5.6-4.13H3.04v2.6A9.99 9.99 0 0 0 12 22Z" fill="#34A853" />
+      <path d="M6.4 13.82a5.99 5.99 0 0 1 0-3.64V7.58H3.04a10 10 0 0 0 0 8.84L6.4 13.82Z" fill="#FBBC05" />
+      <path d="M12 6.38c1.47 0 2.79.5 3.82 1.48l2.86-2.86C16.97 3.45 14.7 2.5 12 2.5a9.99 9.99 0 0 0-8.96 5.08l3.36 2.6C7.18 8.14 9.38 6.38 12 6.38Z" fill="#EA4335" />
+    </svg>
+  );
+}
+
+function XIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" role="img" aria-hidden="true" {...props}>
+      <path d="M18.9 2.1h2.6l-5.7 6.5L22 21.9h-6.4l-4-7.1-4.6 7.1H4.4l6-7.9L2 2.1h6.6l3.6 6.4 4.7-6.4Z" />
+    </svg>
+  );
+}
+
+function GithubIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" role="img" aria-hidden="true" {...props}>
+      <path d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.69c-2.78.6-3.37-1.34-3.37-1.34a2.65 2.65 0 0 0-1.11-1.46c-.91-.62.07-.6.07-.6a2.09 2.09 0 0 1 1.52 1.02 2.12 2.12 0 0 0 2.89.83 2.12 2.12 0 0 1 .63-1.33c-2.22-.25-4.56-1.11-4.56-4.95a3.88 3.88 0 0 1 1-2.68 3.6 3.6 0 0 1 .1-2.64s.84-.27 2.75 1.02a9.52 9.52 0 0 1 5 0c1.9-1.29 2.74-1.02 2.74-1.02a3.6 3.6 0 0 1 .1 2.64 3.88 3.88 0 0 1 1 2.68c0 3.85-2.34 4.69-4.58 4.94a2.38 2.38 0 0 1 .68 1.85v2.74c0 .27.18.58.69.48A10 10 0 0 0 12 2Z" />
+    </svg>
+  );
+}
+
+function FacebookIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" role="img" aria-hidden="true" {...props}>
+      <path d="M22 12a10 10 0 1 0-11.5 9.9v-7h-2.3V12h2.3v-2c0-2.3 1.37-3.6 3.47-3.6.7 0 1.43.12 1.43.12v2.5h-.81c-1.28 0-1.68.8-1.68 1.6V12h2.85l-.45 2.9h-2.4v7A10 10 0 0 0 22 12Z" />
+    </svg>
+  );
+}
+

--- a/docs/screens.md
+++ b/docs/screens.md
@@ -7,7 +7,9 @@ This document tracks every user-facing screen in the VisionForge Console demo. U
 - `/` (`app/page.tsx` → `src/screens/Home/HomeScreen.tsx`)
   - **Purpose:** Landing experience for new users. Presents the create account form with client-side validation, social sign-up placeholders, and links to privacy terms.
 - `/sign-in` (`app/sign-in/page.tsx`)
-  - **Purpose:** Email/password sign-in flow that validates input, exposes demo credentials, and redirects to the dashboard on successful mock authentication.
+  - **Purpose:** Email/password sign-in flow featuring GitHub and Google quick actions, inline validation, and demo credentials guidance before routing to the dashboard after successful mock authentication.
+- `/sign-up` (`app/sign-up/page.tsx`)
+  - **Purpose:** Account creation form collecting email, password, and confirmation with dual submit actions (“Create Account” and “SSO”), social sign-up shortcuts, and policy disclaimers.
 - `/dashboard` (`app/dashboard/page.tsx`)
   - **Purpose:** Placeholder dashboard card shown after sign-in, confirming navigation to the authenticated area of the app.
 - `/privacy` (`app/privacy/page.tsx` → `src/screens/Privacy/PrivacyScreen.tsx`)

--- a/docs/sign-in-screen.md
+++ b/docs/sign-in-screen.md
@@ -1,0 +1,42 @@
+# Sign In screen
+
+## Visual & Interaction Breakdown
+
+The Sign In interface mirrors the sign-up visual language: a compact authentication card centered on a light slate canvas. Copy hierarchy, spacing, and button treatments reuse shadcn/ui primitives to reinforce consistency across the auth journey.
+
+| Element | Role / Function | Font & Weight | Size (px / Tailwind class) | Color | Spacing & Layout | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| **Background** | Root canvas that centers the auth card | `font-sans` | `min-h-screen` | `bg-slate-100` (#F1F5F9) | Flex wrapper `items-center justify-center p-4` | Guarantees breathing room on small screens |
+| **Form Card** | Container for credentials and affordances | Inherits | `w-[350px]` | `bg-white` (#FFFFFF) | Uses shadcn `Card` padding and rounded corners | Matches Sign Up proportions |
+| **Title** | Communicates task focus | `font-semibold` | `text-2xl` via `CardTitle` | `text-slate-900` (#0F172A) | Sits above copy with ~8 px gap | Text: “Sign in to your account” |
+| **Description** | Provides context and helper credentials | `font-normal` | `text-sm` (14 px) | `text-slate-600` (#475569) | Shares header column gap | Embeds bolded `{TEST_CREDENTIALS}` values for quick testing |
+| **Social Choice Row** | Allows direct provider auth | `font-medium` | Buttons ~40 px tall | Outline style `border-slate-200`; icon fill `currentColor` (#0F172A) | `grid grid-cols-2 gap-4` | Buttons show GitHub and Google with inline glyphs |
+| **Separator** | Divides federated auth from form | `font-semibold` | Text `text-[10px]` | Chip text `text-slate-400` (#94A3B8); line inherits `Separator` neutral | Positioned in a `relative` wrapper so the chip sits centered on the rule | Copy: “OR CONTINUE WITH”; uppercase `[0.2em]` tracking |
+| **Label: Email** | Identifies email control | `font-medium` | `text-sm` | `text-slate-900` | `grid gap-2` wrapper ensures 8 px rhythm | Copy: “Email” |
+| **Input: Email** | Captures username/email | `font-normal` | ~40 px height (`h-10`) | Border `#E2E8F0`, text `#0F172A`, placeholder `#94A3B8` | `w-full` | Placeholder “m@example.com”; wires `autoComplete="email"` |
+| **Label: Password** | Identifies password control | `font-medium` | `text-sm` | `text-slate-900` | Same stack spacing | Copy: “Password” |
+| **Input: Password** | Captures password | `font-normal` | ~40 px height | Same as email input | `w-full` | Uses `type="password"` + `autoComplete="current-password"` |
+| **Field Errors** | Inline validation copy | `font-normal` | `text-sm` | `text-red-500` (#EF4444) | Lives directly beneath each input | `role="alert"` and `aria-describedby` provide accessibility |
+| **Primary Action** | Submits credentials | `font-medium` | Button height ~40 px | `bg-slate-900` (#0F172A) text `white` | `w-full` inside footer column | Text toggles between “Sign in” and “Signing in...”; disabled while pending |
+| **Cross-link Text** | Nudges new users to register | `font-normal` | `text-sm` | Base `text-slate-600`; link `font-medium underline text-slate-900` | Sits beneath the button with 12 px gap | Copy: “New to VisionForge? Create an account.” |
+
+### Interaction Notes
+
+- Email & password inputs clear their respective errors as the user types, keeping feedback contextual.
+- The sign-in button controls the same form submit handler and references the social button group via `aria-controls` for assistive tech clarity.
+- On success, `signIn` resolves and the router transitions to `/dashboard`; failures surface a form-level error above the actions.
+- The social provider group exposes semantic labels and retains focus outlines for keyboard navigation.
+
+## Prompt
+
+Create a **“Sign In screen”** that aligns with the Sign Up experience:
+
+1. **Canvas & Card:** Center a 350 px wide white auth card on a `bg-slate-100` flex container using the sans-serif base font.
+2. **Header:** Use `text-2xl font-semibold text-slate-900` for “Sign in to your account” and follow it with `text-sm text-slate-600` copy that highlights demo credentials in bold.
+3. **Federated Buttons:** Add a `grid grid-cols-2 gap-4` row of outline buttons for GitHub and Google, each with a leading 16 px icon and readable labels.
+4. **Divider:** Insert a `Separator` with a centered chip reading “OR CONTINUE WITH” styled as `text-[10px] uppercase tracking-[0.2em] text-slate-400` on a white background.
+5. **Form Fields:** Stack labeled inputs for Email and Password (`text-sm font-medium` labels). Inputs should be 40 px tall, full width, with placeholders, `autoComplete` hints, and inline error states using `text-sm text-red-500` plus accessible IDs.
+6. **Actions:** In the footer, place a full-width primary button (`bg-slate-900 text-white`) that disables and swaps copy to “Signing in...” during submission. Beneath it, show `text-sm text-slate-600` copy linking to the `/sign-up` route with underline styling.
+7. **Behavior:** Wire the form to a mock `signIn` helper, redirect to `/dashboard` on success, and expose a top-level error message above the actions when authentication fails.
+
+Implement the screen in Next.js with Tailwind CSS, shadcn/ui components, and Bun tooling.

--- a/docs/sign-up-screen.md
+++ b/docs/sign-up-screen.md
@@ -1,0 +1,46 @@
+# Sign Up screen
+
+## Visual & Interaction Breakdown
+
+The Sign Up experience lives inside a 350 px wide card that floats above a slate-tinted backdrop. The composition is vertically centered, keeping the hero copy, form, and social affordances within a tight column for optimal scanning. Typography leans on the sans-serif system stack configured by the design system.
+
+| Element | Role / Function | Font & Weight | Size (px / Tailwind class) | Color | Spacing & Layout | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| **Background** | Full-page canvas that grounds the flow | `font-sans` | `min-h-screen` | `bg-slate-100` (#F1F5F9) | Flex wrapper `items-center justify-center p-4` | Provides even breathing room on compact screens |
+| **Form Card** | Structural container for the auth steps | Inherits | `w-[350px]` | `bg-white` (#FFFFFF) with default border transparent | Uses shadcn `Card` padding rhythm; `rounded-xl` & `shadow-sm` from component | Keeps content focused while implying depth |
+| **Title** | Introduces the conversion intent | `font-semibold` | `text-2xl` via `CardTitle` | `text-slate-900` (#0F172A) | Stacks above description with ~8 px gap | Copy: “Create an account” |
+| **Description** | Secondary guidance + link to sign-in | `font-normal` | `text-sm` (`14px`) | Body `text-slate-600` (#475569); link `underline text-slate-900` | Shares `CardHeader` column gap | Inline link routes to `/sign-in` |
+| **Field Group Wrapper** | Wraps each label/input/error trio | `font-sans` | N/A | Transparent | `grid gap-2` | Ensures 8 px vertical rhythm |
+| **Label: Email** | Identifies email control | `font-medium` | `text-sm` | `text-slate-900` | Associates with input using `htmlFor` | Copy: “Email” |
+| **Input: Email** | Captures email address | `font-normal` | ~40 px height (`h-10`) | Border `#E2E8F0`, text `#0F172A`, placeholder `#94A3B8` | `w-full` field width | Placeholder “name@example.com”; invalid state toggles `aria-invalid` |
+| **Label: Password** | Identifies password control | `font-medium` | `text-sm` | `text-slate-900` | Same spacing as email | Copy: “Password” |
+| **Input: Password** | Captures password | `font-normal` | ~40 px height | Same as email input | `w-full` | `type="password"`; `aria-describedby` wires to helper |
+| **Label: Confirm Password** | Verifies password | `font-medium` | `text-sm` | `text-slate-900` | Same as other groups | Copy: “Confirm Password” |
+| **Input: Confirm Password** | Confirmation field | `font-normal` | ~40 px height | Same as email input | `w-full` | Mirrors password semantics |
+| **Primary Submit** | Commits the registration | `font-medium` | Button height ~40 px (`h-10`) | `bg-slate-900` (#0F172A) text `white` | `w-full` inside footer stack | Label: “Create Account”; disabled state `opacity-50`; swaps copy to “Creating...” while pending |
+| **Secondary Submit** | Shortcut for SSO flow discovery | `font-semibold` | Button height ~40 px | `variant="outline"` → border `#CBD5F5`, text `#0F172A` | Sits below primary button with 12 px gap | Label: “SSO”; clicking scrolls focus to provider grid |
+| **Form Error Message** | Surfaces top-level failure | `font-normal` | `text-sm` | `text-red-500` (#EF4444) | Lives above buttons inside footer | Uses `role="alert"` for SR priority |
+| **Separator** | Visually partitions classic vs SSO options | `font-semibold` | Text `text-[10px]` (10 px) | Text `text-slate-400` (#94A3B8) | Absolute chip overlay on `Separator` line | Copy: “OR CONTINUE WITH”; uppercase tracking `[0.2em]` |
+| **Social Grid** | Lists identity providers | `font-normal` | Icon buttons `size="icon"` (~40×40) | Outline buttons `border-slate-200`; icons `text-slate-900` | `grid grid-cols-4 gap-4` | Buttons host sr-only labels and vector glyphs for Google, X, GitHub, Facebook; container receives focus when SSO is invoked |
+| **Legal Copy** | Communicates contractual consent | `font-normal` | `text-xs` (12 px) | `text-slate-500`; links `underline text-slate-900` | `mt-6 text-center` block below grid | Copy: “By creating an account, you agree to our Terms of Service and Privacy Policy.” |
+
+### Interaction Notes
+
+- All fields clear their inline errors on change to keep validation responsive.
+- The SSO button scrolls focus to the provider grid (`tabIndex="-1"`) for keyboard users.
+- Submission locks the form, shows “Creating...” feedback, and resets inputs after a successful mock `signUp` call.
+- Form-level failures appear above the buttons, aligned with accessibility best practices.
+
+## Prompt
+
+Design and build a **“Sign Up screen”** with these parameters:
+
+1. **Canvas:** `min-h-screen` flex container centered on a `bg-slate-100` background using the app’s sans-serif base font.
+2. **Card:** 350 px wide white `Card` with rounded corners and drop shadow; use shadcn/ui spacing primitives.
+3. **Header:** Title “Create an account” (`text-2xl font-semibold text-slate-900`) plus supporting copy referencing the `/sign-in` link styled with `underline text-slate-900`.
+4. **Form:** Stack labeled inputs for Email, Password, and Confirm Password (`text-sm font-medium` labels, 40 px tall inputs with placeholder `name@example.com` for the email control). Show inline errors in `text-sm text-red-500` with `role="alert"` and `aria-describedby` wiring.
+5. **Actions:** Within the `CardFooter`, place two full-width buttons. Primary submit: `bg-slate-900 text-white` labeled “Create Account” with a loading state. Secondary submit: outline style labeled “SSO” that scrolls focus to the provider list.
+6. **Separator & Providers:** Output a centered chip reading “OR CONTINUE WITH” above a four-column grid of icon-only outline buttons for Google, X, GitHub, and Facebook; include sr-only labels and 16 px icons.
+7. **Legal Footer:** Add centered `text-xs text-slate-500` copy referencing `/terms` and `/privacy` links styled with underline treatment.
+
+Implement with Next.js 14+, Tailwind CSS, shadcn/ui components, and Bun scripts.

--- a/lib/mock-auth.ts
+++ b/lib/mock-auth.ts
@@ -23,3 +23,19 @@ export async function signIn(email: string, password: string): Promise<void> {
     }, 300);
   });
 }
+
+export async function signUp(email: string, password: string): Promise<void> {
+  const trimmedEmail = email?.trim() ?? "";
+  const trimmedPassword = password?.trim() ?? "";
+
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (trimmedEmail && trimmedPassword) {
+        resolve();
+        return;
+      }
+
+      reject(new Error("Unable to create account"));
+    }, 300);
+  });
+}


### PR DESCRIPTION
## Summary
- expand the sign up screen documentation with detailed parameters and SSO guidance
- add a companion sign in screen specification and refresh the screen index entry
- enhance the sign up and sign in pages with an SSO control, accessibility tweaks, and cross-navigation copy

## Testing
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c8c43c71a8832ab9456e57c442747e